### PR TITLE
Add the documentation website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,31 @@ All code should be formatted with
 1. `ruff --fix .`
 2. `black .`
 
+## Documentation
+The documentation for this project is located in the `docs` directory and is hosted at
+[django-cypress.helloworldpc.com](https://django-cypress.helloworldpc.com).
+[MkDocs](https://www.mkdocs.org/) is used as the framework and
+[Material](https://squidfunk.github.io/mkdocs-material/) as the theme.
+To view the documentation locally and contribute to it, follow these steps:
+1. Install the required documentation dependencies:
+```
+pip install -r requirements-docs.txt
+```
+2. Navigate to the `docs` directory:
+```
+cd docs
+```
+3. Start a local development server:
+```
+mkdocs serve --dev-addr localhost:3000
+```
+4. Open your web browser and visit [http://localhost:3000](http://localhost:3000) to
+access the local documentation.
+
+We encourage all contributors to keep the documentation up-to-date and comprehensive.
+If you find any errors or have suggestions for improvement, please consider contributing
+to the documentation alongside your code changes.
+
 ## Testing
 
 Before submitting any code changes, it's important to ensure that your 
@@ -176,6 +201,31 @@ class ManageViewTestCase(TestCase):
         expected_status_code = HTTPStatus.OK
         actual_status_code = response.status_code
         self.assertEqual(expected_status_code, actual_status_code)
+```
+6. Add documentation for your command by creating a new file `{command}.md` at [`./docs/docs/commands`](./docs/docs/commands/) directory. This file should use the following structure. View [`manage.md`](./docs/docs/commands/manage.md) example.
+
+```markdown
+# Command name
+
+Command Description
+
+## Syntax
+
+Command Syntax
+
+## Usage
+
+Command Usage
+
+## Arguments
+
+### > argument 1 (Type of the Argument)
+
+Description for the argument 1
+
+### > argument 2 (Type of the Argument)
+
+Description for the argument 2
 ```
 
 ## Developer Certificate of Origin (DCO)

--- a/docs/docs/commands/manage.md
+++ b/docs/docs/commands/manage.md
@@ -1,0 +1,27 @@
+# manage
+
+Run administrative tasks using Django’s command-line utility `manage.py`.
+For example: `python manage.py migrate` or `python manage.py flush`.
+
+## Syntax
+
+```javascript
+cy.manage(command)
+cy.manage(command, options)
+```
+
+## Usage
+
+```javascript
+cy.manage("migrate")
+cy.manage("flush", ["--no-input"])
+```
+
+## Arguments
+### > command ( string )
+
+command should be one of the commands listed in this [document](https://docs.djangoproject.com/en/4.2/ref/django-admin/).
+
+### > options ( string [ ] )
+
+options, which is optional, should be zero or more of the options available for the given command.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,0 +1,62 @@
+# django-cypress
+
+*Out-of-the-box end-to-end testing for Django*
+
+This package provides the necessary boilerplate to quickly begin
+testing your Django applications using Cypress.
+
+## Table of contents
+- [Installation](#installation)
+- [Example project](#example-project)
+- [License](#license)
+
+## Installation
+
+The first step is to install [Cypress](https://www.cypress.io/) as a development dependency.
+```
+npm install cypress --save-dev
+```
+
+Install the `django_cypress` package.
+```
+pip install django_cypress
+```
+
+Add the `django_cypress` app to the `INSTALLED_APPS` to the `settings.py` file:
+```python
+INSTALLED_APPS = [
+    ...
+    'django_cypress'
+    ...
+]
+```
+
+Include the URLs of the `django_cypress` app to the `urls.py` file.
+```python
+urlpatterns = [
+    path("", include("django_cypress.urls")),
+]
+```
+
+Generate the Cypress boilerplate to copy over the initial boilerplate files for your Cypress tests.
+```
+python manage.py cypress_boilerplate
+```
+
+We have provided a `e2e/example.cy.js` spec for you as an example. Open Cypress.
+```
+npx cypress open
+```
+In the Cypress window that appears, select "E2E Testing," followed by
+"Start E2E Testing in Chrome." This action will display a list of all 
+the specs in your application. Click on `example.cy.js` to execute it.
+
+## Example Project
+
+If you're having difficulties setting up a project using `django_cypress`,
+there is an example project that you can refer to [here](https://github.com/HelloWorld-PC/django-cypress/tree/main/example).
+Instructions on running this example project are available in
+this [README.md](https://github.com/HelloWorld-PC/django-cypress/blob/main/example/README.md) file.
+
+## License
+The MIT License (MIT). Please see [License File](https://github.com/HelloWorld-PC/django-cypress/blob/main/LICENSE) for more information.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,3 @@
+site_name: django-cypress
+theme:
+  name: material

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,1 @@
+mkdocs-material ==9.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 -e .[all]
 -r requirements-tests.txt
+-r requirements-docs.txt


### PR DESCRIPTION
## Related issues
Closes #18

## Changes
- Added a website documentation to the `docs` directory
- Used the [MkDocs](https://www.mkdocs.org/) framework and the [Material](https://squidfunk.github.io/mkdocs-material/) theme
- Added detailed instructions in the `CONTRIBUTING.md` regarding documentation
- Added the documentation of the `cy.manage()` command
