### PR TITLE
Add the PyPi publish GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-cypress
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+
+      - name: Set the python version
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build the distributions
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish the package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/requirements-publish.txt
+++ b/requirements-publish.txt
@@ -1,0 +1,3 @@
+setuptools-scm==7.0.5
+twine==4.0.1
+wheel>=0.37.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e .[all]
 -r requirements-tests.txt
 -r requirements-docs.txt
+-r requirements-publish.txt


### PR DESCRIPTION
## Related issues
Closes #20 

## Changes
- Added a GitHub action that publishes the module to [PyPi](https://pypi.org/)