### PR TITLE
Fix permissions issue on publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   pypi-publish:
     name: Upload release to PyPI


### PR DESCRIPTION
## Related Issues
Affects #20 

## Changes
The GitHub Action `actions/checkout` returns this error
```
Run actions/checkout@v3
  
Syncing repository: HelloWorld-PC/django-cypress
Getting Git version info
Temporarily overriding HOME='/home/runner/work/_temp/c898adc2-2333-4aac-a8f9-4b240c095536' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /home/runner/work/django-cypress/django-cypress
Deleting the contents of '/home/runner/work/django-cypress/django-cypress'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +fcfeb243ef297ca[19](https://github.com/HelloWorld-PC/django-cypress/actions/runs/6300194330/job/17102468228#step:3:21)c47f0ad9b5bafbf799e99fb:refs/tags/v0.0.2
  remote: Repository not found.
  Error: fatal: repository 'https://github.com/HelloWorld-PC/django-cypress/' not found
  The process '/usr/bin/git' failed with exit code 128
  Waiting 13 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +fcfeb243ef297ca19c47f0ad9b5bafbf799e99fb:refs/tags/v0.0.2
  remote: Repository not found.
  Error: fatal: repository 'https://github.com/HelloWorld-PC/django-cypress/' not found
  The process '/usr/bin/git' failed with exit code 128
  Waiting 17 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +fcfeb243ef297ca19c[47](https://github.com/HelloWorld-PC/django-cypress/actions/runs/6300194330/job/17102468228#step:3:52)f0ad9b5bafbf799e99fb:refs/tags/v0.0.2
  remote: Repository not found.
  Error: fatal: repository 'https://github.com/HelloWorld-PC/django-cypress/' not found
  Error: The process '/usr/bin/git' failed with exit code 128
```

This pull request tries to fix this error by providing read permissions to the GitHub Action