### PR TITLE
Add cy.migrate() command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,6 +228,7 @@ Description for the argument 1
 
 Description for the argument 2
 ```
+7. Install the [example](./example) project and run the `python manage.py cypress_boilerplate` command.
 
 ## Developer Certificate of Origin (DCO)
 

--- a/django_cypress/stubs/cypress/support/commands.js
+++ b/django_cypress/stubs/cypress/support/commands.js
@@ -20,3 +20,16 @@ Cypress.Commands.add('manage', (command, parameters = []) => {
     });
 })
 
+Cypress.Commands.add('migrate', () => {
+    return cy.csrfToken().then((token) => {
+        return cy.request({
+            method: 'POST',
+            url: '/__cypress__/migrate/',
+            body: {},
+            log: false,
+            headers: {
+                "X-CSRFToken": token["body"]["token"]
+            }
+        });
+    });
+})

--- a/django_cypress/stubs/cypress/support/index.d.ts
+++ b/django_cypress/stubs/cypress/support/index.d.ts
@@ -16,5 +16,12 @@ declare namespace Cypress {
          * cy.csrfToken()
          */
         csrfToken(): Chainable<any>;
+        /**
+         * Run the python manage.py migrate command
+         *
+         * @example
+         * cy.migrate()
+         */
+        migrate(): Chainable<any>;
     }
 }

--- a/django_cypress/urls.py
+++ b/django_cypress/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from .views import CSRFTokenView, ManageView
+from .views import CSRFTokenView, ManageView, MigrateView
 
 urlpatterns = [
     path("__cypress__/manage/", ManageView.as_view(), name="manage-view"),
+    path("__cypress__/migrate/", MigrateView.as_view(), name="migrate-view"),
     path("__cypress__/csrftoken/", CSRFTokenView.as_view(), name="csrftoken-view"),
 ]

--- a/django_cypress/views.py
+++ b/django_cypress/views.py
@@ -6,6 +6,28 @@ from django.middleware.csrf import get_token
 from django.views import View
 
 
+class MigrateView(View):
+    """A view for running Django's migrate command via HTTP POST requests."""
+
+    def post(
+        self,
+        _: HttpRequest,
+    ) -> JsonResponse:
+        """Handle HTTP POST requests to execute Django's migrate command.
+
+        Args:
+        ----
+        request (HttpRequest): The HTTP request object.
+
+        Returns:
+        -------
+        JsonResponse: A JSON response indicating the success of the command execution.
+        """
+        management.call_command("migrate")
+
+        return JsonResponse({"success": True})
+
+
 class ManageView(View):
     """A view for running Django management commands via HTTP POST requests."""
 

--- a/docs/docs/commands/migrate.md
+++ b/docs/docs/commands/migrate.md
@@ -1,0 +1,15 @@
+# migrate
+
+Run the `python manage.py migrate` command.
+
+## Syntax
+
+```javascript
+cy.migrate()
+```
+
+## Usage
+
+```javascript
+cy.migrate()
+```

--- a/example/cypress/e2e/example.cy.js
+++ b/example/cypress/e2e/example.cy.js
@@ -1,4 +1,8 @@
 describe('Example Test', () => {
+    before(() => {
+        cy.migrate();
+    })
+
     it('shows a homepage', () => {
         cy.visit('/');
 

--- a/example/cypress/support/commands.js
+++ b/example/cypress/support/commands.js
@@ -20,3 +20,16 @@ Cypress.Commands.add('manage', (command, parameters = []) => {
     });
 })
 
+Cypress.Commands.add('migrate', () => {
+    return cy.csrfToken().then((token) => {
+        return cy.request({
+            method: 'POST',
+            url: '/__cypress__/migrate/',
+            body: {},
+            log: false,
+            headers: {
+                "X-CSRFToken": token["body"]["token"]
+            }
+        });
+    });
+})

--- a/example/cypress/support/index.d.ts
+++ b/example/cypress/support/index.d.ts
@@ -8,7 +8,7 @@ declare namespace Cypress {
          * @example
          * cy.manage()
          */
-        manage(command: string, parameters?: object): Chainable<any>;
+        manage(command: string, parameters?: string[]): Chainable<any>;
         /**
          * Get the CSRF Token.
          *
@@ -16,5 +16,12 @@ declare namespace Cypress {
          * cy.csrfToken()
          */
         csrfToken(): Chainable<any>;
+        /**
+         * Run the python manage.py migrate command
+         *
+         * @example
+         * cy.migrate()
+         */
+        migrate(): Chainable<any>;
     }
 }

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,6 +6,7 @@ INSTALLED_APPS = [
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "testing",
     }
 }
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -42,7 +42,7 @@ class ManageViewTestCase(TestCase):
         self.client = Client()
 
     def test_run_manage_command(self) -> None:
-        """Do an HTTP GET request to the ManageView.
+        """Do an HTTP POST request to the ManageView.
 
         First of all, create a dummy user. Then run the
         manage.py flush command through the ManageView.
@@ -60,6 +60,28 @@ class ManageViewTestCase(TestCase):
         expected_count = 0
         actual_count = User.objects.all().count()
         self.assertEqual(expected_count, actual_count)
+
+        expected_status_code = HTTPStatus.OK
+        actual_status_code = response.status_code
+        self.assertEqual(expected_status_code, actual_status_code)
+
+
+class MigrateViewTestCase(TestCase):
+    """Test case for the Migrate view."""
+
+    def setUp(self) -> None:
+        """Set up the test case."""
+        self.client = Client()
+
+    def test_run_migrate_command(self) -> None:
+        """Do an HTTP POST request to the MigrateView.
+
+        Run the manage.py migrate command through the MigrateView.
+        Finally, make sure that the HTTP Status Code of
+        the response is 200.
+        """
+        path = reverse("migrate-view")
+        response = self.client.post(path)
 
         expected_status_code = HTTPStatus.OK
         actual_status_code = response.status_code


### PR DESCRIPTION
## Related issues
Closes #34

## Changes
- Added the `cy.migrate()` command that runs the `python manage.py migrate` command
- Added an example case for this command to the `example` directory
- Added documentation regarding this command