### PR TITLE
Add GitHub link to the website

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,3 +1,4 @@
 site_name: django-cypress
+repo_url: https://github.com/HelloWorld-PC/django-cypress
 theme:
   name: material


### PR DESCRIPTION
## Related issues
Closes #46 #47 

## Changes
- Added the GitHub link to the website

> **Note:** The stars / forks will be shown when we make the repository public

## Screenshot
<img width="1507" alt="Screenshot 2023-10-16 at 6 39 51 PM" src="https://github.com/HelloWorld-PC/django-cypress/assets/53979866/167ac6e4-9bf9-4244-b952-f4e37e1a6adb">
