### PR TITLE
Bump to v1.0.1

### DIFF
--- a/django_cypress/__init__.py
+++ b/django_cypress/__init__.py
@@ -1,2 +1,2 @@
 """django-cypress, out-of-the-box end-to-end testing for Django."""
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="django-cypress",
-    version="1.0.0",
+    version="1.0.1",
     description="Integration of Cypress in a Django project.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Changes
- This pull request bumps the `django-cypress` package to `v1.0.1`.
- This pull request was opened for release purposes.